### PR TITLE
Fixes compatibility issues with WooCommerce Multilingual

### DIFF
--- a/woocommerce-gateway-epay-dk/woocommerce-gateway-epay-dk.php
+++ b/woocommerce-gateway-epay-dk/woocommerce-gateway-epay-dk.php
@@ -58,8 +58,12 @@ function add_wc_epay_dk_gateway()
 			$this->remotepassword = $this->settings["remotepassword"];
 			
 			// Actions
-			add_action('init', array(& $this, 'check_callback', ));
-			add_action('valid-epay-callback', array(&$this, 'successful_request', ));
+			
+			// This fixes compatibility issues with WooCommerce Multilingual and WP 4.5.1 rewrite rules.
+			if(stristr($_SERVER['REQUEST_URI'], 'WC_Gateway_EPayDk')) {
+				add_action('init', array(&$this, 'check_callback'));
+				add_action('valid-epay-callback', array(&$this, 'successful_request'));
+			}
 			
 			if($this->settings["remoteinterface"] == "yes")
 				add_action('add_meta_boxes', array( &$this, 'epay_meta_boxes' ), 10, 0);


### PR DESCRIPTION
When WooCommerce Multilingual is activated with WP 4.5.1 it seems that they modify how rewrites of endpoints work.
The idea for this fix comes from the class WCML_WooCommerce_Rest_API_Support in the Multilingual plugin, where they remove rewrite rules filtering for PayPal IPN url.