### PR TITLE
Add language 'nb_NO'

### DIFF
--- a/woocommerce-gateway-epay-dk/lib/epayhelper.php
+++ b/woocommerce-gateway-epay-dk/lib/epayhelper.php
@@ -19,6 +19,7 @@ class EpayHelper
             'en_NZ' => '2',
             'en_US' => '2',
             'sv_SE' => '3',
+            'nb_NO' => '4',
             'nn_NO' => '4',
             );
 


### PR DESCRIPTION
Norway has more than one official written language. Add missing support for the most widespread written language.