### PR TITLE
Added hooks for payment action post-processing

### DIFF
--- a/bambora-online-classic/bambora-online-classic.php
+++ b/bambora-online-classic/bambora-online-classic.php
@@ -914,6 +914,8 @@ function init_bambora_online_classic() {
 								$message .= ' - ' . $webservice->get_pbs_error( $this->merchant, $capture_response->pbsResponse );
 							}
 							return new WP_Error( 'bambora_online_classic_error', $message );
+						} else {
+							do_action( 'bo_after_capture', $order_id );
 						}
 						break;
 					case 'refund':
@@ -928,6 +930,8 @@ function init_bambora_online_classic() {
 								$message .= ' - ' . $webservice->get_pbs_error( $this->merchant, $refund_response->pbsResponse );
 							}
 							return new WP_Error( 'bambora_online_classic_error', $message );
+						}  else {
+							do_action( 'bo_after_chargeback', $order_id );
 						}
 						break;
 					case 'delete':
@@ -938,6 +942,8 @@ function init_bambora_online_classic() {
 								$message .= ' - ' . $webservice->get_epay_error( $this->merchant, $delete_response->epayresponse );
 							}
 							return new WP_Error( 'bambora_online_classic_error', $message );
+						} else {
+							do_action( 'bo_after_delete', $order_id );
 						}
 						break;
 				}


### PR DESCRIPTION
Added Hooks for better 3rd party integration for when capture, refund and delete actions have been performed on a payment through the ePay remote payment webservice.

This also allows the developer to put functions into the functions.php file to e.g. update the WooCommerce order status depending on the actions performed on the authorized payment.
