### PR TITLE
Add missing subscriptions payment meta decleration

### DIFF
--- a/bambora-online-classic/bambora-online-classic.php
+++ b/bambora-online-classic/bambora-online-classic.php
@@ -82,6 +82,7 @@ function init_bambora_online_classic() {
                 'subscription_amount_changes',
                 'subscription_date_changes',
                 'subscription_payment_method_change_customer',
+                'subscription_payment_method_change_admin',
                 'multiple_subscriptions'
                 );
 
@@ -100,6 +101,9 @@ function init_bambora_online_classic() {
             if ( $this->remoteinterface === 'yes' ) {
                 $this->supports = array_merge( $this->supports, array( 'refunds' ) );
             }
+            
+            // Allow store managers to manually set Bambora online classic as the payment method on a subscription
+			add_filter( 'woocommerce_subscription_payment_meta', array( $this, 'add_subscription_payment_meta' ), 10, 2 );
         }
 
         /**
@@ -1056,6 +1060,24 @@ function init_bambora_online_classic() {
                 return new WP_Error( 'bambora_online_classic_error', $message );
             }
         }
+        
+        /**
+        * Add subscripts payment meta, to allow for subscripts import to map tokens, and for admins to manually set a subscription token
+        *
+        * @Link https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter#importing-payment-gateway-meta-data
+        */ 
+        public function add_subscription_payment_meta( $payment_meta, $subscription ) {
+			$payment_meta[ $this->id ] = array(
+				'post_meta' => array(
+					Bambora_Online_Classic_Helper::BAMBORA_ONLINE_CLASSIC_SUBSCRIPTION_ID => array(
+						'value' => Bambora_Online_Classic_Helper::get_bambora_online_classic_subscription_id( $subscription),
+						'label' => __('Bambora subscription token', 'bambora-online-classic'),
+						'disabled' => false,
+					),
+				),
+			);
+			return $payment_meta;
+		}
 
         /**
          * Delete a payment

--- a/bambora-online-classic/bambora-online-classic.php
+++ b/bambora-online-classic/bambora-online-classic.php
@@ -102,8 +102,8 @@ function init_bambora_online_classic() {
                 $this->supports = array_merge( $this->supports, array( 'refunds' ) );
             }
             
-            // Allow store managers to manually set Bambora online classic as the payment method on a subscription
-			add_filter( 'woocommerce_subscription_payment_meta', array( $this, 'add_subscription_payment_meta' ), 10, 2 );
+	    // Allow store managers to manually set Bambora online classic as the payment method on a subscription
+	    add_filter( 'woocommerce_subscription_payment_meta', array( $this, 'add_subscription_payment_meta' ), 10, 2 );
         }
 
         /**


### PR DESCRIPTION
Add subscriptions payment meta, to allow for subscribers import to map tokens, and for admins to manually set a subscription token

https://github.com/woocommerce/woocommerce-subscriptions-importer-exporter#importing-payment-gateway-meta-data

With this added, its possible to use WooCommerce subscriptions import/export, and move subscribers using from another system to WooCommerce, but keeping their subscriptions on Bambora online classic platform.